### PR TITLE
fix(ci): close act-skew gap, bump upload-artifact, plug token leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,12 @@ jobs:
         run: make test
 
       - name: Upload test results
-        if: always()
+        # Skip under local `act` runs — act's embedded artifact-server speaks an
+        # older protobuf format than upload-artifact@v7 (mime_type unknown field),
+        # so 5 retries × 32s are wasted even with continue-on-error: true.
+        if: ${{ always() && !env.ACT }}
         continue-on-error: true
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: '**/TestResults/**'
@@ -117,9 +120,10 @@ jobs:
         run: make integration-test
 
       - name: Upload integration test results
-        if: always()
+        # Skip under local `act` runs — see note on Upload test results above.
+        if: ${{ always() && !env.ACT }}
         continue-on-error: true
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-results
           path: '**/TestResults/**'
@@ -130,8 +134,6 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Skip under local `act` runs (Makefile's ci-run target passes `--var ACT=true`).
-    if: ${{ vars.ACT != 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -147,7 +149,13 @@ jobs:
           dapr --version
 
       - name: Initialize Dapr (standalone mode)
-        run: dapr init
+        # Idempotent: tolerates a pre-existing Dapr install when the workflow runs
+        # under `act` with the host's Docker socket (host may already have
+        # `dapr_placement` running from prior `dapr init`). No-op on fresh
+        # GitHub-hosted runners.
+        run: |
+          dapr uninstall --all 2>/dev/null || true
+          dapr init
 
       - name: End-to-end tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -180,19 +180,19 @@ ci: deps static-check test integration-test build
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflow locally via act (pass GH_ACCESS_TOKEN to avoid mise/aqua GitHub rate-limit inside the container)
+# Security: GITHUB_TOKEN passed via env, not argv, so it does not appear in `ps` output.
+# `act -s GITHUB_TOKEN` (no value) reads from the process environment.
 ci-run: deps
 	@if [ -z "$$GH_ACCESS_TOKEN" ]; then \
 		echo "Warning: GH_ACCESS_TOKEN not set — mise tool resolution inside act will hit the 60/hour unauthenticated rate limit."; \
 		act push --container-architecture linux/amd64 \
 			--artifact-server-path /tmp/act-artifacts \
-			--var ACT=true \
 			--concurrent-jobs 1; \
 	else \
-		act push --container-architecture linux/amd64 \
+		GITHUB_TOKEN="$$GH_ACCESS_TOKEN" act push --container-architecture linux/amd64 \
 			--artifact-server-path /tmp/act-artifacts \
-			--var ACT=true \
 			--concurrent-jobs 1 \
-			--secret GITHUB_TOKEN="$$GH_ACCESS_TOKEN"; \
+			-s GITHUB_TOKEN; \
 	fi
 
 #release: @ Create and push a new tag


### PR DESCRIPTION
## Summary

Follow-up fixes caught during `/ship-it` Stage 5 analysis of [run 24689392397](https://github.com/AndriyKalashnykov/dapr-kafka-csharp/actions/runs/24689392397) (the merge of #68).

## Changes

- **upload-artifact v5 → v7.0.1** — Node 20 deprecated on GitHub Actions runners (forced to Node 24 on 2026-06-02, removed 2026-09-16). v7.0.1 ships Node 24.
- **Drop `if: vars.ACT != 'true'` on the e2e job** — the guard made `make ci-run` skip e2e entirely under act, which is why the missing `Install Dapr CLI` step reached real CI undetected in the prior run. `make ci-run` is now a full mirror.
- **Skip upload-artifact steps under act** (`!env.ACT`) — act's embedded artifact server speaks an older protobuf than upload-artifact@v7 (unknown `mime_type` field); retry-backoff wastes ~60s per ci-run.
- **Idempotent `dapr init`** — `dapr uninstall --all || true && dapr init` tolerates a stale `dapr_placement` container when running under act (host Docker socket). No-op on fresh GitHub-hosted runners.
- **Plug `GH_ACCESS_TOKEN` argv leak in Makefile** — token was visible in `ps` via `--secret GITHUB_TOKEN=<value>`. Now passed via process env + `-s GITHUB_TOKEN` (no value).
- **Drop unused `--var ACT=true`** from Makefile (nothing in the workflow reads `vars.ACT` anymore).

## Test plan

- [x] `make ci-run` — all 6 jobs green (including e2e: PASS=2 FAIL=0, 1m27s)
- [x] `ps` shows `-s GITHUB_TOKEN` without value (token in env only)
- [ ] Watch new CI run on push; confirm e2e passes on GitHub-hosted runner
- [ ] Confirm upload-artifact v7 uploads succeed on real runner (unlike under act)