### PR TITLE
chore: Kafka 4.2 + changes-detector CI migration

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ KAFKA_HOST_2=172.28.1.2
 KAFKA_HOST_3=172.28.1.3
 KAFKA_CLUSTER_ID=4L6g3nShT-eMCtK--X86sw
 # renovate: datasource=docker depName=apache/kafka
-KAFKA_IMAGE=apache/kafka:4.0.2@sha256:836cafdad9f4825880d7cf1d5a21202915ae2527bd0ef1c3600c526ed7814d1f
+KAFKA_IMAGE=apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  # No paths-ignore: CI must always run so the `ci-pass` aggregator always
-  # reports a status. The repository's ruleset requires `ci-pass` before merge,
-  # and a path-filtered trigger would skip the workflow entirely on doc-only
-  # PRs — leaving nothing to report and deadlocking the merge.
+  # No trigger-level paths-ignore: it deadlocks with Repository Rulesets
+  # (workflow never runs → `ci-pass` never reports → required-check gate
+  # never clears). Heavy jobs gate on the `changes` detector below instead.
   push:
     branches: [main]
     tags: ['v*']
@@ -27,7 +26,37 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  # Detector: decide whether the change touches code (heavy jobs run) or is
+  # doc-only (heavy jobs skip; ci-pass treats skipped as pass). See the
+  # `/ci-workflow` skill section "Path-Filter Strategy" for the rationale.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            code:
+              - '!**.md'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.claudeignore'
+              - '!.claude/**'
+              - '!docs/**'
+              - 'CLAUDE.md'
+
   static-check:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,7 +74,8 @@ jobs:
         run: make lint
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -63,7 +93,8 @@ jobs:
         run: make build
 
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -94,7 +125,8 @@ jobs:
           if-no-files-found: ignore
 
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -123,7 +155,8 @@ jobs:
           if-no-files-found: ignore
 
   e2e:
-    needs: [build, test]
+    needs: [changes, build, test]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -301,7 +334,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [static-check, build, test, integration-test, e2e, docker]
+    needs: [changes, static-check, build, test, integration-test, e2e, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,10 +166,13 @@ Deferred items from `/upgrade-analysis` (2026-04-20). Review and resolve on futu
 
 - [ ] **Helm 3 → 4 migration** — Helm 4.1.4 is stable alongside 3.20.2. Helm 4 has SDK/plugin API breaking changes. Pinned on `3.20.2` for now; plan a separate POC before committing.
 - [ ] **K8s Kafka path still on Bitnami** — `scripts/kafka.sh` uses `bitnami/kafka` Helm chart with `bitnamilegacy/kafka:4.0.0-debian-12-r10`. Compose paths migrated to `apache/kafka` 2026-04; K8s path deferred. Options: (a) Strimzi operator, (b) custom chart around `apache/kafka`, (c) paid Broadcom Tanzu Bitnami registry. Track when Bitnami Helm chart itself moves behind the paywall.
-- [ ] **Branch protection on `main` not configured** — `.github/CODEOWNERS` exists, `ci-pass` aggregator exists, but `gh api .../branches/main/protection` returns 404. Enable branch protection with `ci-pass` as the single required check + require code-owner review to make both load-bearing.
-- [ ] **Microsoft.NET.Test.Sdk 18.4.0 ↔ TUnit 1.37.0 compat** — untested on first-run. If `dotnet test` fails with MTP runner errors, pin `Microsoft.NET.Test.Sdk` to a version TUnit's MTP runner was released against (check TUnit release notes).
-- [ ] **Kafka 4.2 upgrade** — compose stays on `apache/kafka:4.0.2` (conservative); bump to 4.2.x when the project has integration tests proving compatibility.
 - [ ] **Bitnami Helm chart succession** — `charts.bitnami.com/bitnami` moved to `repo.broadcom.com/bitnami-files` (302 redirect). If this host goes paywalled or offline, `scripts/kafka.sh` breaks. Monitor.
+
+Resolved:
+
+- [x] **Branch protection on `main`** — Repository Rulesets are active (discovered via direct-push rejection with `GH013: Repository rule violations found`); `ci-pass` is enforced as the required status check.
+- [x] **Microsoft.NET.Test.Sdk ↔ TUnit 1.37.0 compat** — validated by green CI across runs [24689392397](https://github.com/AndriyKalashnykov/dapr-kafka-csharp/actions/runs/24689392397), [24690437810](https://github.com/AndriyKalashnykov/dapr-kafka-csharp/actions/runs/24690437810), and local `make ci-run` under act. TUnit bundles its own MTP runner; `Microsoft.NET.Test.Sdk` is not referenced in test csprojs.
+- [x] **Kafka 4.2 upgrade** — Compose paths bumped to `apache/kafka:4.2.0` (digest-pinned); e2e-compose passes (PASS=2 FAIL=0). K8s path still on Bitnami — tracked separately.
 
 ## Skills
 

--- a/docker-compose-kafka.yaml
+++ b/docker-compose-kafka.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: apache/kafka:4.0.2@sha256:836cafdad9f4825880d7cf1d5a21202915ae2527bd0ef1c3600c526ed7814d1f
+    image: apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9
     ports:
       - "9092:9092"
     healthcheck:


### PR DESCRIPTION
## Summary

Clears two actionable items from the CLAUDE.md Upgrade Backlog and migrates the CI workflow to the portfolio-canonical path-filter pattern.

## Commits

1. **Kafka 4.2 + resolved-backlog cleanup**
   - Bump Compose paths to `apache/kafka:4.2.0` (digest-pinned)
   - Move resolved items from Backlog to a "Resolved" section: branch protection (Rulesets active), .NET Test Sdk ↔ TUnit compat, Kafka 4.2

2. **changes-detector CI migration**
   - Replaces always-on CI (from #70) with `dorny/paths-filter@v4.0.1` gating
   - `static-check`, `build`, `test`, `integration-test`, `e2e` all gated on `needs.changes.outputs.code == 'true'`
   - `docker` unchanged (tag-gated)
   - `ci-pass` picks up `changes` in its `needs:` list; skipped treated as pass
   - Documented in `/ci-workflow` skill "Path-Filter Strategy" section

## Test plan

- [x] `make e2e-compose` against Kafka 4.2.0 — PASS=2 FAIL=0
- [x] `act -l` parses the new workflow cleanly
- [ ] CI green on this PR (code PR → full pipeline runs)
- [ ] Follow-up: validate `code=false` path by merging a doc-only PR (will only run `changes` + `ci-pass`)