### PR TITLE
docs: post-PR-73 documentation refresh — README + CLAUDE.md stale-fact sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ cd producer && dapr run --app-id producer --resources-path ../components -- dotn
 
 `make dapr-run-consumer` and `make dapr-run-producer` invoke `dapr run` under the hood — they are NOT plain `dotnet run`. Without the sidecar, `PublishEventAsync` and the topic subscription do not work.
 
-A 3-node KRaft Kafka cluster with SASL+SSL is available via `docker-compose.yaml` (advanced; requires Dapr component changes):
+A 3-node KRaft Kafka cluster (plaintext) is available via `docker-compose.yaml` (advanced; requires Dapr component changes):
 ```bash
 make local-kafka-run   # Start
 make local-kafka-stop  # Stop
@@ -74,6 +74,7 @@ models/             Shared library (net10.0, no dependencies)
 - Dapr component config: `components/kafka-pubsub.yaml` (shared by producer and consumer for local Compose) / `k8s/kafka-pubsub.yaml` (Kubernetes)
 - Consumer uses `Startup.cs` pattern (not minimal API), with `UseCloudEvents()` middleware to unwrap CloudEvents payloads
 - JSON serialization uses camelCase naming policy (`JsonNamingPolicy.CamelCase`)
+- Consumer error responses follow RFC 7807 ProblemDetails — malformed JSON returns `400 Bad Request` with `application/problem+json` Content-Type and a `{ type, title, status, detail }` body via the `WriteProblemAsync` helper in `consumer/Startup.cs`. Asserted at three layers: integration (Content-Type + body field assertions in `ConsumeMessageTests`), e2e KinD (`e2e/e2e-test.sh`), and e2e Compose (`e2e/e2e-compose-test.sh`).
 
 ## Kubernetes Deployment
 
@@ -87,8 +88,8 @@ make kind-down            # stop cloud-provider-kind and delete the cluster
 # Granular
 make kind-create          # create KinD cluster (image pinned via KIND_NODE_IMAGE, Renovate-tracked)
 make kind-setup           # start cloud-provider-kind daemon (requires sudo for low-port bind)
-make k8s-dapr-deploy      # install Dapr via Helm (chart v1.17.3)
-make k8s-kafka-deploy     # install Kafka (Bitnami chart v32.4.3, Kafka 4.0, SASL)
+make k8s-dapr-deploy      # install Dapr control plane via Helm 4 (chart pinned via DAPR_CHART_VERSION = 1.17.6)
+make k8s-kafka-deploy     # install Strimzi operator (STRIMZI_OPERATOR_VERSION = 1.0.0) + apply k8s/strimzi-kafka.yaml (single-broker KRaft Kafka 4.2.0, plaintext)
 make k8s-image-load       # build images and `kind load docker-image` into the cluster
 make k8s-workload-deploy  # apply namespace + Dapr component + producer + consumer
 
@@ -103,14 +104,13 @@ K8s manifests are in `k8s/` (namespace: `dapr-app`). `deps-k8s` checks for `kind
 
 ## Testing
 
-Test projects live under `tests/` and use **TUnit 1.37.0** (portfolio rule at `~/.claude/rules/dotnet/testing.md` — xUnit/NUnit/MSTest are migration-required) with **FakeItEasy 9.0.1** for mocking:
+Test projects live under `tests/` and use **TUnit 1.44.0** (portfolio rule at `~/.claude/rules/dotnet/testing.md` — xUnit/NUnit/MSTest are migration-required) with **FakeItEasy 9.0.1** for mocking:
 
 | Project | Layer | Notes |
 |---------|-------|-------|
-| `tests/models.UnitTests` | Unit | Pure-data tests on `SampleMessage` |
-| `tests/producer.UnitTests` | Unit | Mocks `DaprClient` via FakeItEasy |
-| `tests/producer.IntegrationTests` | Integration | Real publish loop assertions |
-| `tests/consumer.IntegrationTests` | Integration | `WebApplicationFactory<Program>` for in-process HTTP + CloudEvents |
+| `tests/models.UnitTests` | Unit | `SampleMessage` wire schema — round-trip, camelCase property names, null/empty-string survival |
+| `tests/producer.UnitTests` | Unit | `MessageGeneratorTests` covers the random-message generator; `ProducerPublishTests` covers the publish-loop resilience against transient broker errors (fake `DaprClient` throws on iteration 1, asserts iteration 2 still runs) |
+| `tests/consumer.IntegrationTests` | Integration | `WebApplicationFactory<Program>` for in-process HTTP + CloudEvents middleware + ProblemDetails contract assertions |
 
 The Makefile exposes the three-layer test pyramid:
 
@@ -146,24 +146,28 @@ make mermaid-lint   # Parse every ```mermaid block via pinned minlag/mermaid-cli
 - **K8s safety**: every `kubectl`/`helm` recipe is bound to `--context=kind-$(KIND_CLUSTER_NAME)` via the `KUBECTL` Makefile variable (and the `HELM_CTX` array in `scripts/kafka.sh`). Prevents cross-cluster bleed when other KinD-using projects rewrite `~/.kube/config` mid-session.
 - **Namespaces** are sourced from `DAPR_APP_NS` (`dapr-app`) and `DAPR_SYSTEM_NS` (`dapr-system`) — single source of truth across all Makefile recipes.
 - **Helm version**: Helm 4.x (`aqua:helm/helm = "4.1.4"` in `.mise.toml`). Helm 4 backward-compatibility for `apiVersion: v2` charts is good — both `dapr/dapr` and `strimzi/strimzi-kafka-operator` charts install cleanly under Helm 4 without code changes. We use only `repo add` / `repo update` / `upgrade --install` / `uninstall` / `ls`, all of which behave identically in v3 and v4. Helm 4's plugin SDK is a separate API surface from the CLI; the SDK-only breaking changes don't affect us. Renovate tracks via the mise manager.
-- .NET SDK version pinned in `global.json` (10.0.201, `rollForward: latestMajor`, `allowPrerelease: true`)
+- .NET SDK version pinned in `global.json` (`10.0.203`, `rollForward: latestMajor`, `allowPrerelease: true`). See the **.NET SDK ↔ runtime mapping** bullet above for the SDK/runtime drift story.
 - All projects target `net10.0`
 - Each project has its own `nuget.config` pointing to NuGet v3 feed
 - Docker images: both producer and consumer use `dotnet/aspnet:10.0` base (Dapr.AspNetCore requires ASP.NET runtime)
 - `Directory.Build.props` enforces `TreatWarningsAsErrors` and `RestorePackagesWithLockFile` across all projects
-- Renovate bot manages dependency updates (mise, NuGet, Dockerfiles, docker-compose, GitHub Actions, and inline `# renovate:` comments in Makefile / `.mise.toml`)
+- Renovate covers 81 dependencies across 7 managers: `mise` (`.mise.toml` aqua backends + core tools), `nuget` (`*.csproj`), `dockerfile` (`FROM` digests), `docker-compose` (`image:`), `kubernetes` (`k8s/*.yaml` `image:` fields), `github-actions` (`uses:` refs), and four `custom.regex` managers — Makefile plain version constants, Makefile `repo:tag@sha256:` image refs, `.env` Kafka image, and inline `# renovate:` annotations above env-block constants in `.github/workflows/*.yml` (CST + ZAP versions). `.mise.toml` does NOT carry `# renovate:` comments — the native `mise` manager tracks every entry directly.
 
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main`, tag pushes (`v*`), and pull requests:
 
+- `changes` (`dorny/paths-filter` detector) gates the heavy jobs — doc-only pushes skip downstream without deadlocking the Rulesets `ci-pass` requirement. Force-true on `refs/tags/*` so publish runs always go through the full pipeline
 - `static-check` → gates everything downstream (format + warnings-as-errors + hadolint)
 - `build`, `test`, `integration-test` run in parallel after `static-check` passes
-- `e2e` runs after `build` + `test` (skipped when scaffolded e2e script is missing)
-- On tag pushes (`v*`), a matrix `docker` job runs the full pre-push hardening pipeline:
+- `e2e` (Compose) runs after `build` + `test` — `make e2e-compose` exercises the full Dapr round-trip against a local `apache/kafka:4.2.0` broker
+- `e2e-kind` runs after `build` + `test` — `helm/kind-action` creates a KinD cluster, then `make k8s-dapr-deploy → k8s-kafka-deploy (Strimzi 1.0) → k8s-workload-deploy → k8s-test` validates the production K8s path on every push
+- On tag pushes (`v*`), a matrix `docker` job runs the full pre-push hardening pipeline (5 gates):
   - Gate 1 — local single-arch build (`load: true`) with GHA cache
-  - Gate 2 — Trivy image scan (CRITICAL/HIGH blocking, `scanners: vuln,secret,misconfig`)
+  - Gate 2 — Trivy image scan (CRITICAL/HIGH blocking, `scanners: vuln,secret,misconfig`, `ignore-unfixed: true`)
+  - Gate 2.5 — `container-structure-test` v1.22.1 against `tests/structure/{producer,consumer}.yaml` — asserts `.dll` files present at `/app`, non-root `USER` UID 1654, ENTRYPOINT/WORKDIR match the Dockerfile
   - Gate 3 — Smoke test (boot-marker grep: producer = `Publishing data:`, consumer = `Now listening on:` / `Application started`)
+  - Gate 3.5 — DAST: OWASP ZAP 2.17.0 baseline scan against the consumer's `:6000` endpoint (consumer-only; producer has no HTTP listener). `continue-on-error` because the Dapr-coupled consumer rejects every non-CloudEvents request; the HTML+JSON report uploads as the `zap-baseline-consumer` artifact for manual triage
   - Gate 4 — Multi-arch build + push to GHCR (`linux/amd64`, `linux/arm64`, `provenance: false` + `sbom: false` Pattern A)
   - Gate 5 — Cosign keyless OIDC signing by digest (`id-token: write` required at job level)
 - `ci-pass` aggregates all upstream jobs with `if: always()` — single required status check for branch protection

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/dapr-kafka-csharp)
 
-# Dapr Pub/Sub on Apache Kafka — .NET 10 Reference
+# Dapr Pub/Sub on Apache Kafka — .NET 10 Starter
 
-Two services — a console producer and an ASP.NET Core consumer — exchange `SampleMessage` events through Dapr sidecars backed by Apache Kafka. The consumer uses Dapr's CloudEvents middleware to unwrap payloads and filters on `event.type == com.dapr.event.sent`.
+Delivers a production-ready Dapr pub/sub implementation in C# on .NET 10: a console producer and an ASP.NET Core consumer exchange `SampleMessage` events through Dapr sidecars over Apache Kafka. The consumer unwraps CloudEvents envelopes via Dapr's middleware, filters on `event.type == com.dapr.event.sent`, and returns RFC 7807 ProblemDetails on malformed input. The same workload runs unchanged on two paths — Docker Compose against `apache/kafka:4.2.0` for fast iteration, or Kubernetes via KinD with Dapr 1.17 (Helm 4) and Strimzi 1.0 provisioning a single-broker KRaft Kafka cluster on the `kafka.strimzi.io/v1` API.
 
-Runs locally via Docker Compose (`apache/kafka`) or on Kubernetes via KinD + cloud-provider-kind (Strimzi operator manages upstream Apache Kafka in KRaft mode). The test pyramid covers three layers on TUnit + FakeItEasy: unit (in-process, mocked), integration (in-process via `WebApplicationFactory` + FakeItEasy), and end-to-end (Compose or KinD). The tag-triggered release pipeline Trivy-scans the image, smoke-tests it via boot-marker grep, container-structure-tests metadata, runs an OWASP ZAP DAST baseline against the consumer, publishes multi-arch (amd64/arm64) to GHCR, and cosign-signs by digest.
+A three-layer test pyramid on TUnit 1.44 + FakeItEasy covers unit (wire schema, publish-loop resilience), integration (consumer HTTP, CloudEvents middleware, and ProblemDetails contract via `WebApplicationFactory`), and end-to-end (full Dapr round-trip on Compose and KinD, with the `e2e-kind` CI job validating the production K8s path on every push). Tag releases pass five supply-chain gates before publishing to GHCR — Trivy CVE scan (CRITICAL/HIGH blocking), `container-structure-test` filesystem and non-root posture checks, boot-marker smoke test, OWASP ZAP DAST baseline against the consumer, and cosign keyless OIDC signing of the multi-arch (`linux/amd64` + `linux/arm64`) digest. Renovate tracks every version pin across `.mise.toml`, `Makefile`, NuGet, `.env`, Dockerfiles, k8s manifests, GitHub Actions, and inline workflow annotations (81 deps across 7 managers).
 
 ```mermaid
 C4Context
@@ -27,8 +27,8 @@ C4Context
 | Language | C# on .NET 10 (`10.0.203` via `global.json`) | LTS through 2028-11; matches Dapr.AspNetCore 10 support matrix |
 | Runtime image | `mcr.microsoft.com/dotnet/aspnet:10.0` | Required by Dapr.AspNetCore (pulls in ASP.NET runtime) |
 | Dapr SDK | `Dapr.AspNetCore`, `Dapr.Client` | Idiomatic sidecar integration with CloudEvents unwrapping |
-| Dapr CLI | 1.17.1 (mise-pinned) | Runtime chart is 1.17.5 via `DAPR_CHART_VERSION`; CLI and runtime version independently |
-| Message broker | Apache Kafka 4.x — 4.2.0 (Compose) / 4.0.0 (K8s) | No Zookeeper; `apache/kafka` official image for local Compose; Strimzi operator on K8s pulling the matching `quay.io/strimzi/kafka` image |
+| Dapr CLI | 1.17.1 (mise-pinned) | Runtime chart is 1.17.6 via `DAPR_CHART_VERSION`; CLI and runtime version independently |
+| Message broker | Apache Kafka 4.2.0 | No Zookeeper, KRaft mode. `apache/kafka` official image for local Compose; Strimzi 1.0 operator on K8s pulling `quay.io/strimzi/kafka:1.0.0-kafka-4.2.0` |
 | PubSub component | `sampletopic` (pubsub.kafka) | Topic name and component name match by convention |
 | Container tooling | Docker + Buildx (multi-arch amd64/arm64) | ARM64 coverage for Apple Silicon and Graviton |
 | Kubernetes | KinD + cloud-provider-kind + Dapr Helm chart | Kind-team maintained, single Docker network, host-side LoadBalancer daemon |
@@ -59,7 +59,7 @@ The `dapr-run-*` targets invoke `dapr run --app-id ... -- dotnet run`. Without t
 | [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) | 1.17.1 (mise-pinned) | Run Dapr sidecars locally |
 | [KinD](https://kind.sigs.k8s.io/) | 0.31.0 (mise-pinned) | Local Kubernetes cluster (for `make kind-up`) |
 | [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) | 0.10.0 (mise-pinned) | LoadBalancer controller for KinD (allocates IPs on the `kind` Docker network) |
-| [Helm](https://helm.sh/) | latest | Deploy Dapr/Kafka to Kubernetes (optional) |
+| [Helm](https://helm.sh/) | 4.1.4 (mise-pinned) | Deploy Dapr control plane and Strimzi operator |
 
 Install CLI tooling via mise:
 
@@ -77,9 +77,9 @@ C4Container
     Person(operator, "Operator")
     System_Boundary(app, "Dapr Kafka PubSub") {
         Container(producer, "Producer", ".NET 10 console, Dapr.Client 1.17.9", "Publishes SampleMessage every 10s")
-        Container(producer_dapr, "Dapr Sidecar", "daprd 1.17.5, injected at deploy-time", "Produces to Kafka via pubsub component")
+        Container(producer_dapr, "Dapr Sidecar", "daprd 1.17.6, injected at deploy-time", "Produces to Kafka via pubsub component")
         Container(consumer, "Consumer", ".NET 10, ASP.NET Core, Dapr.AspNetCore 1.17.9", "Handles POST /sampletopic on :6000")
-        Container(consumer_dapr, "Dapr Sidecar", "daprd 1.17.5, injected at deploy-time", "Subscribes to Kafka, delivers CloudEvents")
+        Container(consumer_dapr, "Dapr Sidecar", "daprd 1.17.6, injected at deploy-time", "Subscribes to Kafka, delivers CloudEvents")
     }
     ContainerDb(kafka, "Kafka", "Apache Kafka 4.x (KRaft)", "Topic: sampletopic")
     Rel(operator, producer, "dapr run / make dapr-run-producer")
@@ -103,7 +103,7 @@ flowchart TB
         cpk["cloud-provider-kind<br/>(LoadBalancer daemon)"]
         subgraph cluster["KinD cluster: dapr-kafka<br/>(kindest/node:v1.35.0)"]
             ns_dapr["Namespace: dapr-system<br/>Dapr control plane<br/>(operator · placement · sentry · sidecar-injector)"]
-            ns_kafka["Namespace: kafka<br/>Strimzi operator + Kafka CR<br/>(upstream apache/kafka 4.0, KRaft)"]
+            ns_kafka["Namespace: kafka<br/>Strimzi 1.0 operator + Kafka CR<br/>(upstream apache/kafka 4.2, KRaft)"]
             ns_app["Namespace: dapr-app<br/>producer + consumer pods<br/>(see Event Flow below)"]
         end
     end
@@ -348,9 +348,9 @@ The `docker` job runs the following gates **before** any image is pushed to GHCR
 |---|------|---------|------|
 | 1 | Build local single-arch image | Build regressions on the runner architecture | `docker/build-push-action` with `load: true` |
 | 2 | **Trivy image scan** (CRITICAL/HIGH blocking) | CVEs in the base image, OS packages, build layers | `aquasecurity/trivy-action` with `image-ref:` |
-| 2.5 | **Container structure test** | Image contents and metadata drift — required `.dll` files at `/app`, non-root `USER` UID, ENTRYPOINT/WORKDIR match the Dockerfile, dotnet runtime resolves | `GoogleContainerTools/container-structure-test` against `tests/structure/{producer,consumer}.yaml` |
+| 2.5 | **Container structure test** | Image contents and metadata drift — required `.dll` files at `/app`, non-root `USER` UID, ENTRYPOINT/WORKDIR match the Dockerfile, dotnet runtime resolves | `GoogleContainerTools/container-structure-test` v1.22.1 against `tests/structure/{producer,consumer}.yaml` |
 | 3 | **Smoke test** | Image boots correctly on its own (boot-marker grep; NOT a health-curl, since both apps depend on the Dapr sidecar) | `docker run` + `docker logs` |
-| 3.5 | **DAST — OWASP ZAP baseline** (consumer only) | Passive findings on the consumer's `:6000` endpoint (security headers, TLS posture). Producer skipped — console app, no HTTP listener. `continue-on-error` because the Dapr-coupled consumer rejects every non-CloudEvents request; report uploaded as `zap-baseline-consumer` artifact for triage rather than gating | `zaproxy/zaproxy:stable zap-baseline.py` |
+| 3.5 | **DAST — OWASP ZAP baseline** (consumer only) | Passive findings on the consumer's `:6000` endpoint (security headers, TLS posture). Producer skipped — console app, no HTTP listener. `continue-on-error` because the Dapr-coupled consumer rejects every non-CloudEvents request; report uploaded as `zap-baseline-consumer` artifact for triage rather than gating | `ghcr.io/zaproxy/zaproxy:2.17.0 zap-baseline.py` |
 | 4 | Multi-arch build + push | Publishes for both `linux/amd64` and `linux/arm64` | `docker/build-push-action` |
 | 5 | **Cosign keyless OIDC signing** | Sigstore signature on the manifest digest | `sigstore/cosign-installer` + `cosign sign --yes ...@<digest>` |
 


### PR DESCRIPTION
Two-file documentation refresh surfaced by `/readme` + `/renovate` + `/claude` review against the post-PR-73 `main`. PR #73 (Strimzi 1.0 + Helm 4 + Wave 1) shipped the code/config changes but left several CLAUDE.md and README claims stale.

## README.md (commit `949bd7b`)

**Header**: `Reference` → `Starter` (matches GitHub About field, signals fork-and-ship).

**Description (2 paragraphs)**: rewritten in managerial-outcome tone with concrete numbers (TUnit 1.44, Dapr 1.17, Strimzi 1.0, 81 deps / 7 managers, 5 supply-chain gates). Names the RFC 7807 ProblemDetails contract + `kafka.strimzi.io/v1` API + Helm 4 + `e2e-kind` CI gate.

**Version pin fixes (7)**:
| Location | Was | Now |
|---|---|---|
| Tech Stack Dapr CLI | "Runtime chart is **1.17.5**" | 1.17.6 |
| Tech Stack Message broker | "4.2.0 (Compose) / **4.0.0** (K8s)" | "4.2.0" (collapsed) |
| C4Container Mermaid | `daprd **1.17.5**` (×2) | 1.17.6 |
| Cluster Topology Mermaid | `apache/kafka **4.0**` | 4.2; "Strimzi 1.0 operator" |
| Prerequisites Helm | `**latest**` | `4.1.4 (mise-pinned)` |
| Pre-push hardening CST | (no version) | `v1.22.1` |
| Pre-push hardening DAST | `zaproxy:**stable**` | `ghcr.io/zaproxy/zaproxy:2.17.0` |

## CLAUDE.md (commit `625c4dd`)

**HIGH — factual corrections (5)**:
- Testing table dropped the deleted `producer.IntegrationTests` row (reclassified in PR #73)
- TUnit `1.37.0` → `1.44.0`
- Granular K8s comments: Dapr chart `v1.17.3` → `1.17.6`; Kafka `Bitnami chart v32.4.3, Kafka 4.0, SASL` → `Strimzi 1.0.0 + Kafka 4.2.0 plaintext`
- .NET SDK Key Details bullet `10.0.201` → `10.0.203` (resolved internal contradiction)

**MEDIUM — scope corrections (5)**:
- Renovate Key Details bullet enumerates all 7 managers + 4 customManagers (was an outdated short list)
- CI section now describes `changes` job, `e2e-kind` job, and Gates 2.5 (CST v1.22.1) + 3.5 (ZAP 2.17.0 DAST)
- Architecture section names the RFC 7807 ProblemDetails contract + where it's asserted

**LOW — accuracy (1)**:
- 3-node compose: "SASL+SSL" → "plaintext"

## Validation

- `make mermaid-lint` passes
- `grep -nE '1\.17\.[3-5]\|10\.0\.201\|TUnit 1\.37\|producer\.IntegrationTests\|Bitnami chart\|SASL\+SSL'` returns zero hits across CLAUDE.md and README.md
- /claude skill checklist 1–10 all pass (Skills table canonical, subagent instruction present, Upgrade Backlog hygiene clean — single class-(a) item with named trigger)
- /renovate review: no findings against post-PR-73 config

## Test plan

- [x] Mermaid lint
- [x] Stale-pin grep (zero hits)
- [x] /claude checklist items 1–10
- [x] /renovate review pass