### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,8 @@ ci-run: deps
 release: deps
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		if git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; fi && \
+		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		echo $$newtag > ./version.txt && \
 		git add -A && \


### PR DESCRIPTION
Adds local + remote pre-existence guards on the interactively-read `$newtag` in the `release` recipe, before the confirm prompt and any mutation (version.txt write / commit / tag). Prevents the dangling "Cut vX release" commit + half-published release when re-run with an existing tag (Makefile Safety Check #16). Clean-tree tolerance (`git diff --cached --quiet ||`) was already present.

Verified: `make -n release` parses; feeding an existing tag (`v0.0.1`) errors at the guard before any commit/tag, leaving the tree clean.