### PR TITLE
fix(e2e): build solution once to end concurrent-build race in compose e2e

### DIFF
--- a/e2e/e2e-compose-test.sh
+++ b/e2e/e2e-compose-test.sh
@@ -46,15 +46,27 @@ else
     exit 1
 fi
 
+section "Build solution once (before starting apps)"
+# Build the whole solution up front so the consumer and producer are launched with
+# `dotnet run --no-build`. Two concurrent `dotnet run` invocations in the same checkout
+# otherwise race on MSBuild of the shared `models` project — both rewrite
+# models/bin/Debug/net10.0/models.deps.json and the second build dies with
+# "The process cannot access the file ... because it is being used by another process"
+# (MSB4018 / GenerateDepsFile). Building once, then `--no-build`, removes the race
+# deterministically. Config MUST be Debug so the pre-built output matches `dotnet run`'s
+# default configuration.
+dotnet build dapr-kafka-csharp.slnx -c Debug --nologo -v q
+echo "Solution built"
+
 section "Start consumer with Dapr sidecar"
-(cd consumer && dapr run --app-id consumer --app-port 6000 --resources-path ../components --log-level warn -- dotnet run) \
+(cd consumer && dapr run --app-id consumer --app-port 6000 --resources-path ../components --log-level warn -- dotnet run --no-build) \
     > "${LOG_CONSUMER}" 2>&1 &
 PIDS+=($!)
 # Give consumer + sidecar time to register subscription.
 sleep 10
 
 section "Start producer with Dapr sidecar"
-(cd producer && dapr run --app-id producer --resources-path ../components --log-level warn -- dotnet run) \
+(cd producer && dapr run --app-id producer --resources-path ../components --log-level warn -- dotnet run --no-build) \
     > "${LOG_PRODUCER}" 2>&1 &
 PIDS+=($!)
 


### PR DESCRIPTION
## Problem

`main` was red: the `e2e` (Compose) job failed on the post-merge run of #75 (`c084b0a`).

Root cause — **not a flake**: `e2e/e2e-compose-test.sh` starts both `dapr run … -- dotnet run` (consumer, then producer 10s later) in the same checkout. Each `dotnet run` rebuilds the shared `models` project, and the two MSBuilds race on `models/bin/Debug/net10.0/models.deps.json`:

```
error MSB4018: The "GenerateDepsFile" task failed unexpectedly.
System.IO.IOException: The process cannot access the file '.../models/models.deps.json'
because it is being used by another process.
```

The producer's build dies → it never publishes → `FAIL: no message delivered within 60s`. `e2e-kind` is unaffected because each workload builds into a separate image.

## Fix

Build the whole solution **once** up front (Debug, matching `dotnet run`'s default config), then launch both apps with `dotnet run --no-build`. The concurrent-build race is removed deterministically, and the e2e is slightly faster (no duplicate builds).

## Verification

`make e2e-compose` locally → **`PASS=5 FAIL=0`** (consumer receives a message via Dapr pub/sub, producer logs publish, ProblemDetails negative case all green). `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)