### PR TITLE
ci: gate static-check on a docs filter so mermaid-lint + diagrams-check run on doc changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
       # `docker` publish job. Force-true on tag refs so tag runs always go through
       # the full pipeline including publish + sign.
       code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
+      # `docs` gates ONLY `static-check` (which carries mermaid-lint + diagrams-check),
+      # so a docs-only change (README Mermaid flowcharts, or a docs/diagrams/*.puml edit)
+      # still runs those drift gates while the heavy jobs (build/test/e2e/e2e-kind) stay
+      # gated on `code` and skip. Without this, a docs-only change makes code=false →
+      # static-check skips → mermaid-lint AND diagrams-check are bypassed for exactly the
+      # files they guard. See /ci-workflow §15h refinement (a).
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -61,10 +68,17 @@ jobs:
               - '!.claude/**'
               - '!docs/**'
               - 'CLAUDE.md'
+            # Markdown (README Mermaid flowcharts) + diagram sources/renders. Gates
+            # static-check only, so mermaid-lint + diagrams-check run on doc-only changes.
+            docs:
+              - '**.md'
+              - 'docs/**'
 
   static-check:
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # Also run on docs-only changes so mermaid-lint + diagrams-check validate the
+    # README Mermaid flowcharts and the C4-PlantUML diagrams. Heavy jobs stay on `code`.
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Two diagram gates are wired into `static-check`:
 
 GitHub Actions (`.github/workflows/ci.yml`) runs on push to `main`, tag pushes (`v*`), and pull requests:
 
-- `changes` (`dorny/paths-filter` detector) gates the heavy jobs — doc-only pushes skip downstream without deadlocking the Rulesets `ci-pass` requirement. Force-true on `refs/tags/*` so publish runs always go through the full pipeline
+- `changes` (`dorny/paths-filter` detector) gates the heavy jobs — doc-only pushes skip downstream without deadlocking the Rulesets `ci-pass` requirement. Force-true on `refs/tags/*` so publish runs always go through the full pipeline. A second `docs` output (`**.md` + `docs/**`) gates **only** `static-check` so a doc-only change (README Mermaid flowcharts, `docs/diagrams/*.puml`) still runs `mermaid-lint` + `diagrams-check` while `build`/`test`/`e2e`/`e2e-kind` skip
 - `static-check` → gates everything downstream (format + warnings-as-errors + hadolint)
 - `build`, `test`, `integration-test` run in parallel after `static-check` passes
 - `e2e` (Compose) runs after `build` + `test` — `make e2e-compose` exercises the full Dapr round-trip against a local `apache/kafka:4.2.0` broker

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ GitHub Actions runs on push to `main`, tag pushes (`v*`), and pull requests. The
 
 | Job | Triggers | Steps |
 |-----|----------|-------|
-| **changes** | push, PR, tags | `dorny/paths-filter` detector — sets `outputs.code` so doc-only changes skip heavy jobs without deadlocking the Rulesets gate. Force-true on `refs/tags/*` |
+| **changes** | push, PR, tags | `dorny/paths-filter` detector — `outputs.code` skips heavy jobs on doc-only changes (no Rulesets deadlock); `outputs.docs` gates `static-check` only so `mermaid-lint` + `diagrams-check` still run on Markdown/`docs/` edits. Force-true on `refs/tags/*` |
 | **static-check** | code change | Format check, warnings-as-errors, hadolint |
 | **build** | after static-check | Build the solution |
 | **test** | after static-check | Run unit tests, upload results artifact |


### PR DESCRIPTION
## Gap (addresses deferred item #1)

The `code` paths-filter excludes `**.md` and `docs/**`, and `static-check` gated on `code == 'true'`. So a **docs-only change** (a README Mermaid flowchart edit, or a `docs/diagrams/*.puml` edit) makes `code=false` → `static-check` skips → **both `mermaid-lint` and `diagrams-check` are bypassed for exactly the files they guard.** A broken flowchart or a stale committed C4 PNG could merge unvalidated.

This is worse than the efficiency nit originally flagged — it's a correctness hole in the drift gates added for the diagram migration.

## Fix (`/ci-workflow` §15h refinement (a))

Add a `docs` filter output (`**.md` + `docs/**`) that gates **only** `static-check`:
- Docs-only change → `changes` → `static-check` (runs `mermaid-lint` + `diagrams-check`) → `ci-pass`. Heavy jobs (`build`/`test`/`e2e`/`e2e-kind`) stay gated on `code` and **skip**; `ci-pass` stays green (skipped ≠ failure).
- Code change → unchanged (full pipeline).
- Tag push → unchanged (`code` force-true).

CLAUDE.md + README CI tables synced.

## Verification
- `python3 -c yaml.safe_load` valid; **`actionlint` clean**; all 9 jobs intact; `ci-pass` needs unchanged.
- This PR touches `ci.yml` (code) so it runs the full pipeline — proving the change doesn't break heavy-job gating.
- The follow-up **C4 Deployment diagram PR (docs-only) will be the live probe**: with this merged, that PR must run only `changes`/`static-check`/`ci-pass` with the heavy jobs skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)