### PR TITLE
[THROWAWAY] probe: docs-filter skip verification

### DIFF
--- a/docs/diagrams/c4-context.puml
+++ b/docs/diagrams/c4-context.puml
@@ -32,3 +32,5 @@ Rel(dkc, kafka, "Publishes / subscribes via Dapr sidecar", "Kafka protocol")
 
 SHOW_LEGEND()
 @enduml
+
+' probe: verify docs-filter skips heavy jobs (throwaway)


### PR DESCRIPTION
Throwaway probe — verifies the C2 filter fix skips heavy jobs on a docs-only change. Will be closed after observing job selection. Expected: only changes + static-check + ci-pass run; build/test/integration-test/e2e/e2e-kind SKIP.